### PR TITLE
Fix CI branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
     branches:
       - main
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
This repo still uses `master`, oops.