### PR TITLE
Refactor build queueing, add new perf pipeline under new name

### DIFF
--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -48,22 +48,6 @@ function getVSTSTypeScriptClient() {
  *   sourceVersion: string;
  *   parameters: string;
  * }} BuildVars
- * 
- * @typedef {{
- *     resources?: {
- *         repositories?: Record<string, { refName?: string; version?: string } | undefined>;
- *     };
- *     variables?: Record<string, { isSecret?: boolean; value?: string; } | undefined>;
- *     templateParameters?: Record<string, string | number | boolean | undefined>;
- *     queue?: undefined;
- *     sourceBranch?: undefined;
- *     sourceVersion?: undefined;
- *     parameters?: undefined;
- * }} PipelineRunArgs
- * 
- * @typedef {{
- *     _links: { web: { href: string }; };
- * }} PipelineRunResult
  */
 
 /**
@@ -96,6 +80,20 @@ async function makeNewBuildWithComments(request, suiteName, definitionId, log, b
     })
 }
 
+
+/**
+ * @typedef {{
+ *     resources?: {
+ *         repositories?: Record<string, { refName?: string; version?: string } | undefined>;
+ *     };
+ *     variables?: Record<string, { isSecret?: boolean; value?: string; } | undefined>;
+ *     templateParameters?: Record<string, string | number | boolean | undefined>;
+ *     queue?: undefined;
+ *     sourceBranch?: undefined;
+ *     sourceVersion?: undefined;
+ *     parameters?: undefined;
+ * }} PipelineRunArgs
+ */
 
 /**
  * Authenticate with github and vsts, make a comment saying what's being done, then schedule the build

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -40,7 +40,7 @@ function getVSTSTypeScriptClient() {
  * @param {string} suiteName The frindly name to call the suite in the associated comment
  * @param {number} definitionId The VSTS id of the build definition to trigger
  * @param {(s: string) => void} log
- * @param {(pr: any, commentId: number) => Promise<string>} buildTrigger
+ * @param {(pr: Client.Octokit.PullsGetResponse, commentId: number) => Promise<string>} buildTrigger
  */
 async function commentAndTriggerBuild(request, suiteName, definitionId, log, buildTrigger) {
     log(`New build for ${suiteName} (${definitionId}) on ${request.issue.number}`)

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -127,7 +127,6 @@ async function triggerBuild(request, pr, definitionId, log, buildTriggerAugmento
     return response.result;
 }
 
-
 /**
  * @param {any} request
  * @param {string} event
@@ -310,7 +309,7 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
                 entrypoint: "tsserver",
-                prng_seed: pr.id.toString(),
+                prng_seed: pr.id
             },
         };
     })))

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -4,7 +4,7 @@ const crypto = require("crypto");
 const assert = require("assert");
 
 // We cache the clients below this way if a single comment executes two commands, we only bother creating the client once
-/** @type {{GH?: Client.Octokit, vstsTypescript?: vsts.WebApi, vstsDevdiv?: vsts.WebApi}} */
+/** @type {{GH?: Client.Octokit, vstsTypescript?: vsts.WebApi}} */
 let clients = {};
 
 function getGHClient() {
@@ -18,6 +18,8 @@ function getGHClient() {
         return clients.GH;
     }
 }
+
+const typeScriptProjectId = "cf7ac146-d525-443c-b23c-0d58337efebc";
 
 function getVSTSTypeScriptClient() {
     if (clients.vstsTypescript) {
@@ -33,19 +35,16 @@ function getVSTSTypeScriptClient() {
 
 /**
  * @typedef {{
- *   definition: {
- *       id: number;
+ *   resources?: {
+ *     repositories?: Record<string, { refName?: string; version?: string } | undefined>;
  *   };
- *   queue: {
- *       id: number;
- *   };
- *   project: {
- *       id: string;
- *   };
- *   sourceBranch: string;
- *   sourceVersion: string;
- *   parameters: string;
- * }} BuildVars
+ *   variables?: Record<string, { isSecret?: boolean; value?: string; } | undefined>;
+ *   templateParameters?: Record<string, string | number | boolean | undefined>;
+ * }} PipelineRunArgs
+ * 
+ * @typedef {{
+ *   _links: { web: { href: string }; };
+ * }} PipelineRunResult
  */
 
 /**
@@ -55,7 +54,7 @@ function getVSTSTypeScriptClient() {
  * @param {string} suiteName The frindly name to call the suite in the associated comment
  * @param {number} definitionId The VSTS id of the build definition to trigger
  * @param {(s: string) => void} log
- * @param {(x: BuildVars) => (Promise<BuildVars> | BuildVars)} buildTriggerAugmentor maps the intial build request into an enhanced one
+ * @param {(x: PipelineRunArgs) => (Promise<PipelineRunArgs> | PipelineRunArgs)} buildTriggerAugmentor maps the intial build request into an enhanced one
  */
 async function makeNewBuildWithComments(request, suiteName, definitionId, log, buildTriggerAugmentor = p => p) {
     log(`New build for ${suiteName} (${definitionId}) on ${request.issue.number}`)
@@ -73,7 +72,7 @@ async function makeNewBuildWithComments(request, suiteName, definitionId, log, b
     });
     const commentId = result.data.id;
     log(`Created new "started running" comment ${commentId}`)
-    const buildQueue = await triggerBuild(request, pr, definitionId, log, p => buildTriggerAugmentor({ ...p, parameters: JSON.stringify({ ...JSON.parse(p.parameters), status_comment: commentId }) }));
+    const buildQueue = await triggerBuild(request, pr, definitionId, log, p => buildTriggerAugmentor({ ...p, templateParameters: { ...p.templateParameters, comment_id: commentId }}));
     log(`Build done queueing`)
     await cli.issues.updateComment({
         owner: "microsoft",
@@ -90,25 +89,44 @@ async function makeNewBuildWithComments(request, suiteName, definitionId, log, b
  * @param {*} pr The github PR data object
  * @param {number} definitionId The VSTS id of the build definition to trigger
  * @param {(s: string) => void} log
- * @param {(x: BuildVars) => (Promise<BuildVars> | BuildVars)} buildTriggerAugmentor maps the intial build request into an enhanced one
+ * @param {(x: PipelineRunArgs) => (Promise<PipelineRunArgs> | PipelineRunArgs)} buildTriggerAugmentor maps the intial build request into an enhanced one
+ * @returns {Promise<PipelineRunResult>}
  */
 async function triggerBuild(request, pr, definitionId, log, buildTriggerAugmentor = p => p) {
     log(`Trigger build ${definitionId} on ${request.issue.number}`)
     const build = await getVSTSTypeScriptClient().getBuildApi();
     log("Got VSTS Client's Build API")
+
+    // The new pipelines API is not yet supported by the node client, so we have to do this manually.
+    // The request was reverse engineered from the HTTP requests made by the azure devops UI, the node client, and the Go client (which has implemented this).
+    // https://github.com/microsoft/azure-devops-go-api/blob/8dbf8bfd3346f337d914961fab01df812985dcb8/azuredevops/v7/pipelines/client.go#L446
+    const verData = await build.vsoClient.getVersioningData("7.1-preview.1", "pipelines", "7859261e-d2e9-4a68-b820-a5d84cc5bb3d", { project: typeScriptProjectId, pipelineId: definitionId });
+    const url = verData.requestUrl;
+    const options = build.createRequestOptions('application/json', verData.apiVersion);
+    assert(url);
+
     const requestingUser = request.comment.user.login;
-    let buildParams = /** @type BuildVars & { templateParameters: Record<string, string> } */ (await buildTriggerAugmentor({
-        definition: { id: definitionId },
-        queue: { id: 26 },
-        project: { id: "cf7ac146-d525-443c-b23c-0d58337efebc" },
-        sourceBranch: `refs/pull/${pr.number}/merge`, // Undocumented, but used by the official frontend
-        sourceVersion: ``, // Also undocumented
-        parameters: JSON.stringify({ source_issue: pr.number, requesting_user: requestingUser }), // This API is real bad
-    }));
-    buildParams.templateParameters = JSON.parse(buildParams.parameters);
-    log(`Final template parameters after augmentation: ${JSON.stringify(buildParams.templateParameters)}`)
-    return await build.queueBuild(buildParams, "TypeScript");
+    /** @type {PipelineRunArgs} */
+    let args = {
+        resources: {
+            repositories: {
+                self: {
+                    refName: `refs/pull/${pr.number}/merge`,
+                }
+            }
+        },
+        templateParameters: {
+            source_issue: pr.number,
+            requesting_user: requestingUser,
+        }
+    }
+    args = await buildTriggerAugmentor(args);
+
+    log(`Final template parameters after augmentation: ${JSON.stringify(args)}`)
+    const response = await build.rest.create(url, args, options);
+    return response.result;
 }
+
 
 /**
  * @param {any} request
@@ -203,12 +221,18 @@ async function makeCherryPickPR(request, targetBranch, produceLKG, log) {
     }
     await makeNewBuildWithComments(request, `task to cherry-pick this into \`${targetBranch}\``, 30, log, p => ({
         ...p,
-        sourceBranch: `refs/pull/${pr.number}/head`,
-        parameters: JSON.stringify({
-            ...JSON.parse(p.parameters),
+        resources: {
+            repositories: {
+                self: {
+                    refName: `refs/pull/${pr.number}/head`,
+                }
+            }
+        },
+        templateParameters: {
+            ...p.templateParameters,
             target_branch: targetBranch,
             ...(produceLKG ? {PRODUCE_LKG: "true"} : {})
-        })
+        },
     }));
 }
 
@@ -240,20 +264,23 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
     .set(/perf test(?: this)? faster/, action(async (request, log) => await makeNewBuildWithComments(request, "abridged perf test suite", 45, log, p => ({...p, queue: { id: 22 }}))))
     .set(/run dt(?! slower)/, action(async (request, log) => await makeNewBuildWithComments(request, "parallelized Definitely Typed test suite", 23, log, async p => ({
         ...p,
-        parameters: JSON.stringify({
-            ...JSON.parse(p.parameters),
-            DT_SHA: (await getGHClient().repos.getBranch({owner: "DefinitelyTyped", repo: "DefinitelyTyped", branch: "master"})).data.commit.sha
-        })
+        templateParameters: {
+            ...p.templateParameters,
+            DT_SHA: (await getGHClient().repos.getBranch({owner: "DefinitelyTyped", repo: "DefinitelyTyped", branch: "master"})).data.commit.sha,
+        }
     }))))
     .set(/user test this slower/, action(async (request, log) => await makeNewBuildWithComments(request, "community code test suite", 24, log, async p => {
         const cli = getGHClient();
         const pr = (await cli.pulls.get({ pull_number: request.issue.number, owner: "microsoft", repo: "TypeScript" })).data;
 
-        return {...p, parameters: JSON.stringify({
-            ...JSON.parse(p.parameters),
-            target_fork: pr.head.repo.owner.login,
-            target_branch: pr.head.ref
-        })};
+        return {
+            ...p,
+            templateParameters: {
+                ...p.templateParameters,
+                target_fork: pr.head.repo.owner.login,
+                target_branch: pr.head.ref,
+            },
+        };
     })))
     .set(/user test this(?: inline)?(?! slower)/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite", 47, log, async p => {
         const cli = getGHClient();
@@ -261,13 +288,13 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
+            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch.
+            templateParameters: {
+                ...p.templateParameters,
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref
-            })
+            },
         };
     })))
     .set(/user test tsserver/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite (tsserver)", 47, log, async p => {
@@ -276,15 +303,15 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
+            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
+            templateParameters: {
+                ...p.templateParameters,
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
                 entrypoint: "tsserver",
-                prng_seed: pr.id,
-            })
+                prng_seed: pr.id.toString(),
+            },
         };
     })))
     .set(/test top(\d{1,3})/, action(async (request, log, match) => await makeNewBuildWithComments(request, "diff-based top-repos suite", 47, log, async p => {
@@ -294,15 +321,15 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
+            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
+            templateParameters: {
+                ...p.templateParameters,
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
                 top_repos: true,
                 repo_count: numRepos,
-            })
+            },
         };
     })))
     .set(/test tsserver top(\d{1,3})/, action(async (request, log, match) => await makeNewBuildWithComments(request, "diff-based top-repos suite (tsserver)", 47, log, async p => {
@@ -313,8 +340,9 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
         return {
             ...p,
             sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
+            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
+            templateParameters: {
+                ...p.templateParameters,
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
@@ -322,7 +350,7 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
                 repo_count: numRepos,
                 entrypoint: "tsserver",
                 prng_seed: pr.id,
-            })
+            },
         };
     })))
     .set(/cherry-?pick (?:this )?(?:in)?to (\S+)( and LKG)?/, action(async (request, log, match) => await makeCherryPickPR(request, match[1], !!match[2], log)))

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -307,7 +307,8 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
     .set(/perf test(?: this)?(?! this)(?! faster)/, action(async (request, log) => await makeNewBuildWithComments(request, "perf test suite", 22, log, p => ({...p, queue: { id: 22 }}))))
     .set(/perf test(?: this)? faster/, action(async (request, log) => await makeNewBuildWithComments(request, "abridged perf test suite", 45, log, p => ({...p, queue: { id: 22 }}))))
     .set(/new perf test(?: this)?(?: (\S+)?)?/, action(async (request, log, match) => {
-        const preset = match[1] || "regular";
+        let preset = match[1] || "regular";
+        if (preset === "faster") preset = "tsc-only";
 
         await makeNewPipelineRunWithComments(request, `${preset} perf test suite`, 69, log, p => {
             // makeNewPipelineRunWithComments assumes that the pipeline is defined on TypeScript,

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -35,15 +35,15 @@ function getVSTSTypeScriptClient() {
 
 /**
  * @typedef {{
- *   resources?: {
- *     repositories?: Record<string, { refName?: string; version?: string } | undefined>;
- *   };
- *   variables?: Record<string, { isSecret?: boolean; value?: string; } | undefined>;
- *   templateParameters?: Record<string, string | number | boolean | undefined>;
+ *     resources?: {
+ *         repositories?: Record<string, { refName?: string; version?: string } | undefined>;
+ *     };
+ *     variables?: Record<string, { isSecret?: boolean; value?: string; } | undefined>;
+ *     templateParameters?: Record<string, string | number | boolean | undefined>;
  * }} PipelineRunArgs
  * 
  * @typedef {{
- *   _links: { web: { href: string }; };
+ *     _links: { web: { href: string }; };
  * }} PipelineRunResult
  */
 

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -338,7 +338,6 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            sourceBranch: "",
             resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
             templateParameters: {
                 ...p.templateParameters,

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -4,7 +4,7 @@ const crypto = require("crypto");
 const assert = require("assert");
 
 // We cache the clients below this way if a single comment executes two commands, we only bother creating the client once
-/** @type {{GH?: Client.Octokit, vstsTypescript?: vsts.WebApi}} */
+/** @type {{GH?: Client.Octokit, vstsTypescript?: vsts.WebApi, vstsDevdiv?: vsts.WebApi}} */
 let clients = {};
 
 function getGHClient() {
@@ -35,11 +35,30 @@ function getVSTSTypeScriptClient() {
 
 /**
  * @typedef {{
+ *   definition: {
+ *       id: number;
+ *   };
+ *   queue: {
+ *       id: number;
+ *   };
+ *   project: {
+ *       id: string;
+ *   };
+ *   sourceBranch: string;
+ *   sourceVersion: string;
+ *   parameters: string;
+ * }} BuildVars
+ * 
+ * @typedef {{
  *     resources?: {
  *         repositories?: Record<string, { refName?: string; version?: string } | undefined>;
  *     };
  *     variables?: Record<string, { isSecret?: boolean; value?: string; } | undefined>;
  *     templateParameters?: Record<string, string | number | boolean | undefined>;
+ *     queue?: undefined;
+ *     sourceBranch?: undefined;
+ *     sourceVersion?: undefined;
+ *     parameters?: undefined;
  * }} PipelineRunArgs
  * 
  * @typedef {{
@@ -54,9 +73,86 @@ function getVSTSTypeScriptClient() {
  * @param {string} suiteName The frindly name to call the suite in the associated comment
  * @param {number} definitionId The VSTS id of the build definition to trigger
  * @param {(s: string) => void} log
- * @param {(x: PipelineRunArgs) => (Promise<PipelineRunArgs> | PipelineRunArgs)} buildTriggerAugmentor maps the intial build request into an enhanced one
+ * @param {(x: BuildVars) => (Promise<BuildVars> | BuildVars)} buildTriggerAugmentor maps the intial build request into an enhanced one
  */
 async function makeNewBuildWithComments(request, suiteName, definitionId, log, buildTriggerAugmentor = p => p) {
+    await commentAndTriggerBuild(request, suiteName, definitionId, log, async (pr) => {
+        log(`Trigger build ${definitionId} on ${request.issue.number}`)
+        const build = await getVSTSTypeScriptClient().getBuildApi();
+        log("Got VSTS Client's Build API")
+        const requestingUser = request.comment.user.login;
+        let buildParams = /** @type BuildVars & { templateParameters: Record<string, string> } */ (await buildTriggerAugmentor({
+            definition: { id: definitionId },
+            queue: { id: 26 },
+            project: { id: typeScriptProjectId },
+            sourceBranch: `refs/pull/${pr.number}/merge`, // Undocumented, but used by the official frontend
+            sourceVersion: ``, // Also undocumented
+            parameters: JSON.stringify({ source_issue: pr.number, requesting_user: requestingUser }), // This API is real bad
+        }));
+        buildParams.templateParameters = JSON.parse(buildParams.parameters);
+        log(`Final template parameters after augmentation: ${JSON.stringify(buildParams.templateParameters)}`)
+        const response = await build.queueBuild(buildParams, "TypeScript");
+        return response._links.web.href;
+    })
+}
+
+
+/**
+ * Authenticate with github and vsts, make a comment saying what's being done, then schedule the build
+ * and update the comment with the build log URL.
+ * @param {*} request The request object
+ * @param {string} suiteName The frindly name to call the suite in the associated comment
+ * @param {number} definitionId The VSTS id of the build definition to trigger
+ * @param {(s: string) => void} log
+ * @param {(x: PipelineRunArgs) => (Promise<PipelineRunArgs> | PipelineRunArgs)} buildTriggerAugmentor maps the intial build request into an enhanced one
+ */
+async function makeNewPipelineRunWithComments(request, suiteName, definitionId, log, buildTriggerAugmentor = p => p) {
+    await commentAndTriggerBuild(request, suiteName, definitionId, log, async (pr) => {
+        log(`Trigger pipeline ${definitionId} on ${request.issue.number}`)
+        const build = await getVSTSTypeScriptClient().getBuildApi();
+        log("Got VSTS Client's Build API")
+
+        // The new pipelines API is not yet supported by the node client, so we have to do this manually.
+        // The request was reverse engineered from the HTTP requests made by the azure devops UI, the node client, and the Go client (which has implemented this).
+        // https://github.com/microsoft/azure-devops-go-api/blob/8dbf8bfd3346f337d914961fab01df812985dcb8/azuredevops/v7/pipelines/client.go#L446
+        const verData = await build.vsoClient.getVersioningData("7.1-preview.1", "pipelines", "7859261e-d2e9-4a68-b820-a5d84cc5bb3d", { project: typeScriptProjectId, pipelineId: definitionId });
+        const url = verData.requestUrl;
+        const options = build.createRequestOptions('application/json', verData.apiVersion);
+        assert(url);
+
+        const requestingUser = request.comment.user.login;
+        /** @type {PipelineRunArgs} */
+        let args = {
+            resources: {
+                repositories: {
+                    self: {
+                        refName: `refs/pull/${pr.number}/merge`,
+                    }
+                }
+            },
+            templateParameters: {
+                source_issue: pr.number,
+                requesting_user: requestingUser,
+            }
+        }
+        args = await buildTriggerAugmentor(args);
+
+        log(`Final template parameters after augmentation: ${JSON.stringify(args)}`)
+        const response = await build.rest.create(url, args, options);
+        return response.result._links.web.href;
+    })
+}
+
+/**
+ * Authenticate with github and vsts, make a comment saying what's being done, then schedule the build
+ * and update the comment with the build log URL.
+ * @param {*} request The request object
+ * @param {string} suiteName The frindly name to call the suite in the associated comment
+ * @param {number} definitionId The VSTS id of the build definition to trigger
+ * @param {(s: string) => void} log
+ * @param {(pr: any) => Promise<string>} buildTrigger
+ */
+async function commentAndTriggerBuild(request, suiteName, definitionId, log, buildTrigger) {
     log(`New build for ${suiteName} (${definitionId}) on ${request.issue.number}`)
     const cli = getGHClient();
     log("Got github client")
@@ -72,59 +168,15 @@ async function makeNewBuildWithComments(request, suiteName, definitionId, log, b
     });
     const commentId = result.data.id;
     log(`Created new "started running" comment ${commentId}`)
-    const buildQueue = await triggerBuild(request, pr, definitionId, log, p => buildTriggerAugmentor({ ...p, templateParameters: { ...p.templateParameters, comment_id: commentId }}));
+    const buildUrl = await buildTrigger(pr);
     log(`Build done queueing`)
     await cli.issues.updateComment({
         owner: "microsoft",
         repo: "TypeScript",
         comment_id: commentId,
-        body: `Heya @${requestingUser}, I've started to run the ${suiteName} on this PR at ${refSha}. You can monitor the build [here](${buildQueue._links.web.href}).`
+        body: `Heya @${requestingUser}, I've started to run the ${suiteName} on this PR at ${refSha}. You can monitor the build [here](${buildUrl}).`
     });
     log(`Updated to "build is queued" comment ${commentId}`)
-}
-
-/**
- * Authenticate with vsts and schedule the build
- * @param {*} request The request object
- * @param {*} pr The github PR data object
- * @param {number} definitionId The VSTS id of the build definition to trigger
- * @param {(s: string) => void} log
- * @param {(x: PipelineRunArgs) => (Promise<PipelineRunArgs> | PipelineRunArgs)} buildTriggerAugmentor maps the intial build request into an enhanced one
- * @returns {Promise<PipelineRunResult>}
- */
-async function triggerBuild(request, pr, definitionId, log, buildTriggerAugmentor = p => p) {
-    log(`Trigger build ${definitionId} on ${request.issue.number}`)
-    const build = await getVSTSTypeScriptClient().getBuildApi();
-    log("Got VSTS Client's Build API")
-
-    // The new pipelines API is not yet supported by the node client, so we have to do this manually.
-    // The request was reverse engineered from the HTTP requests made by the azure devops UI, the node client, and the Go client (which has implemented this).
-    // https://github.com/microsoft/azure-devops-go-api/blob/8dbf8bfd3346f337d914961fab01df812985dcb8/azuredevops/v7/pipelines/client.go#L446
-    const verData = await build.vsoClient.getVersioningData("7.1-preview.1", "pipelines", "7859261e-d2e9-4a68-b820-a5d84cc5bb3d", { project: typeScriptProjectId, pipelineId: definitionId });
-    const url = verData.requestUrl;
-    const options = build.createRequestOptions('application/json', verData.apiVersion);
-    assert(url);
-
-    const requestingUser = request.comment.user.login;
-    /** @type {PipelineRunArgs} */
-    let args = {
-        resources: {
-            repositories: {
-                self: {
-                    refName: `refs/pull/${pr.number}/merge`,
-                }
-            }
-        },
-        templateParameters: {
-            source_issue: pr.number,
-            requesting_user: requestingUser,
-        }
-    }
-    args = await buildTriggerAugmentor(args);
-
-    log(`Final template parameters after augmentation: ${JSON.stringify(args)}`)
-    const response = await build.rest.create(url, args, options);
-    return response.result;
 }
 
 /**
@@ -220,18 +272,12 @@ async function makeCherryPickPR(request, targetBranch, produceLKG, log) {
     }
     await makeNewBuildWithComments(request, `task to cherry-pick this into \`${targetBranch}\``, 30, log, p => ({
         ...p,
-        resources: {
-            repositories: {
-                self: {
-                    refName: `refs/pull/${pr.number}/head`,
-                }
-            }
-        },
-        templateParameters: {
-            ...p.templateParameters,
+        sourceBranch: `refs/pull/${pr.number}/head`,
+        parameters: JSON.stringify({
+            ...JSON.parse(p.parameters),
             target_branch: targetBranch,
             ...(produceLKG ? {PRODUCE_LKG: "true"} : {})
-        },
+        })
     }));
 }
 
@@ -263,23 +309,20 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
     .set(/perf test(?: this)? faster/, action(async (request, log) => await makeNewBuildWithComments(request, "abridged perf test suite", 45, log, p => ({...p, queue: { id: 22 }}))))
     .set(/run dt(?! slower)/, action(async (request, log) => await makeNewBuildWithComments(request, "parallelized Definitely Typed test suite", 23, log, async p => ({
         ...p,
-        templateParameters: {
-            ...p.templateParameters,
-            DT_SHA: (await getGHClient().repos.getBranch({owner: "DefinitelyTyped", repo: "DefinitelyTyped", branch: "master"})).data.commit.sha,
-        }
+        parameters: JSON.stringify({
+            ...JSON.parse(p.parameters),
+            DT_SHA: (await getGHClient().repos.getBranch({owner: "DefinitelyTyped", repo: "DefinitelyTyped", branch: "master"})).data.commit.sha
+        })
     }))))
     .set(/user test this slower/, action(async (request, log) => await makeNewBuildWithComments(request, "community code test suite", 24, log, async p => {
         const cli = getGHClient();
         const pr = (await cli.pulls.get({ pull_number: request.issue.number, owner: "microsoft", repo: "TypeScript" })).data;
 
-        return {
-            ...p,
-            templateParameters: {
-                ...p.templateParameters,
-                target_fork: pr.head.repo.owner.login,
-                target_branch: pr.head.ref,
-            },
-        };
+        return {...p, parameters: JSON.stringify({
+            ...JSON.parse(p.parameters),
+            target_fork: pr.head.repo.owner.login,
+            target_branch: pr.head.ref
+        })};
     })))
     .set(/user test this(?: inline)?(?! slower)/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite", 47, log, async p => {
         const cli = getGHClient();
@@ -287,13 +330,13 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch.
-            templateParameters: {
-                ...p.templateParameters,
+            sourceBranch: "",
+            parameters: JSON.stringify({
+                ...JSON.parse(p.parameters),
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref
-            },
+            })
         };
     })))
     .set(/user test tsserver/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite (tsserver)", 47, log, async p => {
@@ -302,15 +345,15 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
-            templateParameters: {
-                ...p.templateParameters,
+            sourceBranch: "",
+            parameters: JSON.stringify({
+                ...JSON.parse(p.parameters),
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
                 entrypoint: "tsserver",
-                prng_seed: pr.id
-            },
+                prng_seed: pr.id,
+            })
         };
     })))
     .set(/test top(\d{1,3})/, action(async (request, log, match) => await makeNewBuildWithComments(request, "diff-based top-repos suite", 47, log, async p => {
@@ -320,15 +363,15 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
-            templateParameters: {
-                ...p.templateParameters,
+            sourceBranch: "",
+            parameters: JSON.stringify({
+                ...JSON.parse(p.parameters),
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
                 top_repos: true,
                 repo_count: numRepos,
-            },
+            })
         };
     })))
     .set(/test tsserver top(\d{1,3})/, action(async (request, log, match) => await makeNewBuildWithComments(request, "diff-based top-repos suite (tsserver)", 47, log, async p => {
@@ -338,9 +381,9 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
 
         return {
             ...p,
-            resources: undefined, // This pipeline is in typescript-error-deltas; clear this so just use default branch
-            templateParameters: {
-                ...p.templateParameters,
+            sourceBranch: "",
+            parameters: JSON.stringify({
+                ...JSON.parse(p.parameters),
                 post_result: true,
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
@@ -348,7 +391,7 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
                 repo_count: numRepos,
                 entrypoint: "tsserver",
                 prng_seed: pr.id,
-            },
+            })
         };
     })))
     .set(/cherry-?pick (?:this )?(?:in)?to (\S+)( and LKG)?/, action(async (request, log, match) => await makeCherryPickPR(request, match[1], !!match[2], log)))


### PR DESCRIPTION
~~This changes the code to use the new pipelines run API rather than the old build queueing API. The new API gets rid of the wart that required parameters be stored as strings (my favorite comment, "This API is real bad") in favor of an object. The downside is that they haven't exposed this API directly in the Node client yet (https://github.com/microsoft/azure-devops-node-api/issues/519), but it wasn't hard to figure out via watching the UI requests and reading the Go API client which _does_ support this API.~~

~~This allows allow me to change the perf run tasks to specify the new pipeline and use new repo resources (which I've chosen over what typescript-error-deltas does via a param as it works better in the UI; we could change the error deltas pipelines at some point too).~~

~~From what I can tell, the new API should still work on the old builds; I tested a few by hand and they worked, but it's a little hard to tell for the old-style UI pipelines which don't exactly have a "real" parameters set. I'm going to try and double check for each of these, though.~~

This PR has changed since I sent it, but it effectively abstracts away the pipeline/build triggering sep a bit, leaving the original ones unchanged, and adds a new pipeline trigger for the new perf stuff, which will eventually just replace the old one.