### PR TITLE
Rework bot to use new status comment system

### DIFF
--- a/.github/actions/post-workflow-result/action.yml
+++ b/.github/actions/post-workflow-result/action.yml
@@ -1,0 +1,106 @@
+name: Post workflow result
+
+inputs:
+  success_comment:
+    required: true
+    type: string
+  failure_comment:
+    required: true
+    type: string
+
+  github_token:
+    required: true
+    type: string
+  distinct_id:
+    required: true
+    type: string
+  source_issue:
+    required: true
+    type: string
+  requesting_user:
+    required: true
+    type: string
+  status_comment:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Post workflow result
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      env:
+        SUCCESS_COMMENT: ${{ inputs.success_comment }}
+        FAILURE_COMMENT: ${{ inputs.failure_comment }}
+        SUCCESS: ${{ job.status == 'success' }}
+        DISTINCT_ID: ${{ inputs.distinct_id }}
+        SOURCE_ISSUE: ${{ inputs.source_issue }}
+        REQUESTING_USER: ${{ inputs.requesting_user }}
+        STATUS_COMMENT: ${{ inputs.status_comment }}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const {
+            SUCCESS_COMMENT,
+            FAILURE_COMMENT,
+            SUCCESS,
+            DISTINCT_ID,
+            SOURCE_ISSUE,
+            REQUESTING_USER,
+            STATUS_COMMENT,
+          } = process.env;
+
+          const success = SUCCESS === "true";
+
+          let commentBody = `Hey, @${REQUESTING_USER}! `;
+          commentBody += success ? SUCCESS_COMMENT : FAILURE_COMMENT;
+          if (!success) {
+            commentBody += `\n\nCheck the logs at: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          }
+
+          // Post results
+          const resultsComment = await github.rest.issues.createComment({
+            issue_number: +SOURCE_ISSUE,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: commentBody,
+          });
+
+          const emoji = success ? "✅" : "❌";
+
+          const toReplace = `<!--result-${DISTINCT_ID}-->`;
+          let posted = false;
+          for (let i = 0; i < 5; i++) {
+            // Get status comment contents
+            const statusComment = await github.rest.issues.getComment({
+              comment_id: +STATUS_COMMENT,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const oldComment = statusComment.data.body;
+            if (!oldComment?.includes(toReplace)) {
+              posted = true
+              break;
+            }
+
+            const newComment = oldComment.replace(
+              toReplace,
+              `[${emoji} Results](${resultsComment.data.html_url})`,
+            )
+
+            // Update status comment
+            await github.rest.issues.updateComment({
+              comment_id: +STATUS_COMMENT,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: newComment,
+            });
+
+            // Repeat; someone may have edited the comment at the same time.
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+
+          if (!posted) {
+            throw new Error("Failed to update status comment");
+          }

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -483,10 +483,6 @@ const commands = (/** @type {Map<RegExp, Command>} */ (new Map()))
     }, undefined, false))
 
 const botCall = "@typescript-bot";
-for (const [key, value] of [...commands.entries()]) {
-    commands.delete(key);
-    commands.set(new RegExp(`${botCall} ${key.source}`, "i"), value);
-}
 
 /**
  * @param {string} distinctId

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -1,11 +1,11 @@
 const { app } = require("@azure/functions");
 const { verify: verifyWebhook } = require("@octokit/webhooks-methods");
-const Client = require("@octokit/rest");
+const { Octokit } = require("octokit");
 const vsts = require("azure-devops-node-api");
 const assert = require("assert");
 
 // We cache the clients below this way if a single comment executes two commands, we only bother creating the client once
-/** @type {{GH?: Client.Octokit, vstsTypescript?: vsts.WebApi, vstsDevdiv?: vsts.WebApi}} */
+/** @type {{GH?: Octokit["rest"], vstsTypescript?: vsts.WebApi}} */
 let clients = {};
 
 function getGHClient() {
@@ -13,9 +13,9 @@ function getGHClient() {
         return clients.GH;
     }
     else {
-        clients.GH = new Client.Octokit({
-            auth: process.env.GITHUB_TOKEN
-        });
+        const token = process.env.GITHUB_TOKEN;
+        assert(token, "GITHUB_TOKEN must be set");
+        clients.GH = new Octokit({ auth: token }).rest;
         return clients.GH;
     }
 }
@@ -42,7 +42,6 @@ async function sleep(ms) {
         setTimeout(r, ms);
     });
 }
-
 
 /**
  * @typedef {import("@octokit/webhooks-types").AuthorAssociation} AuthorAssociation

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -243,14 +243,6 @@ async function createWorkflowDispatch({ workflowId, info, inputs }) {
 
 
 const commands = (/** @type {Map<RegExp, Command>} */ (new Map()))
-    .set(/run dt slower/, createCommand((request) => {
-        return queueBuild({
-            definitionId: 18,
-            sourceBranch: `refs/pull/${request.issueNumber}/merge`,
-            info: request,
-            inputs: {}
-        })
-    }))
     .set(/pack this/, createCommand((request) => {
         return queueBuild({
             definitionId: 19,
@@ -273,7 +265,7 @@ const commands = (/** @type {Map<RegExp, Command>} */ (new Map()))
             }
         })
     }))
-    .set(/run dt(?! slower)/, createCommand(async (request) => {
+    .set(/run dt/, createCommand(async (request) => {
         return queueBuild({
             definitionId: 23,
             sourceBranch: `refs/pull/${request.issueNumber}/merge`,

--- a/GithubCommentReader/index.js
+++ b/GithubCommentReader/index.js
@@ -2,7 +2,6 @@ const { app } = require("@azure/functions");
 const { verify: verifyWebhook } = require("@octokit/webhooks-methods");
 const Client = require("@octokit/rest");
 const vsts = require("azure-devops-node-api");
-const crypto = require("crypto");
 const assert = require("assert");
 
 // We cache the clients below this way if a single comment executes two commands, we only bother creating the client once
@@ -36,98 +35,119 @@ function getVSTSTypeScriptClient() {
 }
 
 /**
+ * @param {number} ms
+ */
+async function sleep(ms) {
+    return new Promise(r => {
+        setTimeout(r, ms);
+    });
+}
+
+
+/**
+ * @typedef {import("@octokit/webhooks-types").AuthorAssociation} AuthorAssociation
+ * @typedef {{ kind: "unresolvedGitHub"; distinctId: string }} UnresolvedGitHubRun
+ * @typedef {{ kind: "resolved"; distinctId: string; url: string }} ResolvedRun
+ * @typedef {{ kind: "error"; distinctId: string; error: string }} ErrorRun
+ * @typedef {UnresolvedGitHubRun | ResolvedRun | ErrorRun} Run
+ * 
  * @typedef {{
- *     issueNumber: number;
+ *     log: (s: string) => void;
+ *     match: RegExpMatchArray;
+ *     distinctId: string;
+ *     issueNumber: number; // TODO(jakebailey): rename this
  *     isPr: boolean;
  *     requestingUser: string;
- *     statusCommentId: number;
+ *     statusCommentId: number; // TODO(jakebailey): rename this
  * }} RequestInfo
+ * @typedef {(request: RequestInfo) => Promise<Run>} CommandFn
+ * @typedef {{ fn: CommandFn; authorAssociations: AuthorAssociation[]; prOnly: boolean }} Command
  */
 void 0;
 
 /**
- * Authenticate with github and vsts, make a comment saying what's being done, then schedule the build
- * and update the comment with the build log URL.
- * @param {RequestInfo} request The request object
- * @param {string} suiteName The frindly name to call the suite in the associated comment
- * @param {number} definitionId The VSTS id of the build definition to trigger
- * @param {(s: string) => void} log
- * @param {(pr: Client.RestEndpointMethodTypes["pulls"]["get"]["response"]["data"], commentId: number) => Promise<string>} buildTrigger
+ * @param {CommandFn} fn
+ * @param {AuthorAssociation[]} authorAssociations
+ * @param {boolean} prOnly
+ * @returns {Command}
  */
-async function commentAndTriggerBuild(request, suiteName, definitionId, log, buildTrigger) {
-    log(`New build for ${suiteName} (${definitionId}) on ${request.issueNumber}`)
-    const cli = getGHClient();
-    log("Got github client")
-    const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
-    log(`Got pr for ${request.issueNumber}`)
-    const refSha = pr.head.sha;
-    const requestingUser = request.requestingUser;
-    const result = await cli.issues.createComment({
-        body: `Heya @${requestingUser}, I'm starting to run the ${suiteName} on this PR at ${refSha}. Hold tight - I'll update this comment with the log link once the build has been queued.`,
-        issue_number: pr.number,
-        owner: "microsoft",
-        repo: "TypeScript"
-    });
-    const commentId = result.data.id;
-    log(`Created new "started running" comment ${commentId}`)
-    const buildUrl = await buildTrigger(pr, commentId);
-    log(`Build done queueing`)
-    await cli.issues.updateComment({
-        owner: "microsoft",
-        repo: "TypeScript",
-        comment_id: commentId,
-        body: `Heya @${requestingUser}, I've started to run the ${suiteName} on this PR at ${refSha}. You can monitor the build [here](${buildUrl}).`
-    });
-    log(`Updated to "build is queued" comment ${commentId}`)
+function createCommand(fn, authorAssociations = ["MEMBER", "OWNER", "COLLABORATOR"], prOnly = true) {
+    return { fn, authorAssociations, prOnly };
 }
 
 /**
  * @typedef {{
- *   definition: {
- *       id: number;
- *   };
- *   queue: {
- *       id: number;
- *   };
- *   project: {
- *       id: string;
- *   };
- *   sourceBranch: string;
- *   sourceVersion: string;
- *   parameters: string;
+ *     definition: {
+ *         id: number;
+ *     };
+ *     project: {
+ *         id: string;
+ *     };
+ *     sourceBranch: string;
+ *     sourceVersion: string;
+ *     parameters: string;
+ *     templateParameters: Record<string, string>
  * }} BuildVars
  */
+void 0;
 
 /**
- * Authenticate with github and vsts, make a comment saying what's being done, then schedule the build
- * and update the comment with the build log URL.
- * @param {RequestInfo} request The request object
- * @param {string} suiteName The frindly name to call the suite in the associated comment
- * @param {number} definitionId The VSTS id of the build definition to trigger
- * @param {(s: string) => void} log
- * @param {(x: BuildVars) => (Promise<BuildVars> | BuildVars)} buildTriggerAugmentor maps the intial build request into an enhanced one
+ * @param {RequestInfo} info
+ * @param {Record<string, string>} inputs
  */
-async function makeNewBuildWithComments(request, suiteName, definitionId, log, buildTriggerAugmentor = p => p) {
-    await commentAndTriggerBuild(request, suiteName, definitionId, log, async (pr, commentId) => {
-        log(`Trigger build ${definitionId} on ${request.issueNumber}`)
-        const build = await getVSTSTypeScriptClient().getBuildApi();
-        log("Got VSTS Client's Build API")
-        const requestingUser = request.requestingUser;
-        let buildParams = /** @type BuildVars & { templateParameters: Record<string, string> } */ (await buildTriggerAugmentor({
-            definition: { id: definitionId },
-            queue: { id: 26 },
-            project: { id: typeScriptProjectId },
-            sourceBranch: `refs/pull/${pr.number}/merge`, // Undocumented, but used by the official frontend
-            sourceVersion: ``, // Also undocumented
-            parameters: JSON.stringify({ source_issue: pr.number, requesting_user: requestingUser, status_comment: commentId }), // This API is real bad
-        }));
-        buildParams.templateParameters = JSON.parse(buildParams.parameters);
-        log(`Final template parameters after augmentation: ${JSON.stringify(buildParams.templateParameters)}`)
-        const response = await build.queueBuild(buildParams, "TypeScript");
-        return response._links.web.href;
-    })
+function createParameters(info, inputs) {
+    /** @type {Record<string, string>} */
+    const parameters = {
+        distinct_id: info.distinctId,
+        source_issue: `${info.issueNumber}`,
+        requesting_user: info.requestingUser,
+        status_comment: `${info.statusCommentId}`,
+    };
+
+    const requiredParameters = Object.keys(parameters);
+    const confliciting = Object.keys(inputs).filter((key) => requiredParameters.includes(key));
+    assert(confliciting.length === 0, `Inputs conflict with required parameters: ${confliciting.join(", ")}`);
+
+    Object.assign(parameters, inputs);
+
+    return parameters;
 }
 
+/**
+ * This queues a build using the legacy AzDO build API.
+ * 
+ * @typedef {{
+ *    definitionId: number;
+ *    sourceBranch: string;
+ *    info: RequestInfo;
+ *    inputs: Record<string, string>;
+ * }} QueueBuildRequest
+ * 
+ * @param {QueueBuildRequest} arg
+ * @returns {Promise<ResolvedRun>}
+ */
+async function queueBuild({ definitionId, sourceBranch, info, inputs }) {
+    const parameters = createParameters(info, inputs);
+
+    /** @type {BuildVars} */
+    const buildParams = {
+        definition: { id: definitionId },
+        project: { id: typeScriptProjectId },
+        sourceBranch, // Undocumented, but used by the official frontend
+        sourceVersion: ``, // Also undocumented
+        parameters: JSON.stringify(parameters), // This API is real bad
+        templateParameters: parameters,
+    };
+
+    info.log(`Trigger build ${definitionId} on ${info.issueNumber}`)
+    const build = await getVSTSTypeScriptClient().getBuildApi();
+    const response = await build.queueBuild(buildParams, "TypeScript");
+    return {
+        kind: "resolved",
+        distinctId: info.distinctId,
+        url: response._links.web.href
+    };
+}
 
 /**
  * @typedef {{
@@ -144,257 +164,190 @@ async function makeNewBuildWithComments(request, suiteName, definitionId, log, b
  */
 
 /**
- * Authenticate with github and vsts, make a comment saying what's being done, then schedule the build
- * and update the comment with the build log URL.
- * @param {RequestInfo} request The request object
- * @param {string} suiteName The frindly name to call the suite in the associated comment
- * @param {number} definitionId The VSTS id of the build definition to trigger
- * @param {(s: string) => void} log
- * @param {(x: PipelineRunArgs) => (Promise<PipelineRunArgs> | PipelineRunArgs)} buildTriggerAugmentor maps the intial build request into an enhanced one
- */
-async function makeNewPipelineRunWithComments(request, suiteName, definitionId, log, buildTriggerAugmentor = p => p) {
-    await commentAndTriggerBuild(request, suiteName, definitionId, log, async (pr, commentId) => {
-        log(`Trigger pipeline ${definitionId} on ${request.issueNumber}`)
-        const build = await getVSTSTypeScriptClient().getBuildApi();
-        log("Got VSTS Client's Build API")
+ * This queues a build using the AzDO Pipelines API.
+ * 
+ * @typedef {{
+*    definitionId: number;
+*    repositories: Record<string, { refName?: string; version?: string } | undefined>
+*    info: RequestInfo;
+*    inputs: Record<string, string>;
+* }} CreatePipelineRunRequest
+* 
+* @param {CreatePipelineRunRequest} arg
+* @returns {Promise<ResolvedRun>}
+*/
+async function createPipelineRun({ definitionId, repositories, info, inputs }) {
+    const parameters = createParameters(info, inputs);
 
-        // The new pipelines API is not yet supported by the node client, so we have to do this manually.
-        // The request was reverse engineered from the HTTP requests made by the azure devops UI, the node client, and the Go client (which has implemented this).
-        // https://github.com/microsoft/azure-devops-go-api/blob/8dbf8bfd3346f337d914961fab01df812985dcb8/azuredevops/v7/pipelines/client.go#L446
-        const verData = await build.vsoClient.getVersioningData("7.1-preview.1", "pipelines", "7859261e-d2e9-4a68-b820-a5d84cc5bb3d", { project: typeScriptProjectId, pipelineId: definitionId });
-        const url = verData.requestUrl;
-        const options = build.createRequestOptions('application/json', verData.apiVersion);
-        assert(url);
-
-        const requestingUser = request.requestingUser;
-        /** @type {PipelineRunArgs} */
-        let args = {
-            resources: {
-                repositories: {
-                    self: {
-                        refName: `refs/pull/${pr.number}/merge`,
-                    }
-                }
-            },
-            templateParameters: {
-                source_issue: pr.number,
-                requesting_user: requestingUser,
-                status_comment: commentId,
-            }
-        }
-        args = await buildTriggerAugmentor(args);
-
-        log(`Final template parameters after augmentation: ${JSON.stringify(args)}`)
-        const response = await build.rest.create(url, args, options);
-        return response.result._links.web.href;
-    })
-}
-
-/**
- * @param {RequestInfo} request
- * @param {string} event
- * @param {Record<string, unknown>} payload
- */
-async function triggerGHAction(request, event, payload) {
-    const cli = getGHClient();
-    const requestingUser = request.requestingUser;
-    try {
-        await cli.repos.createDispatchEvent({
-            owner: "microsoft",
-            repo: "TypeScript",
-            event_type: event,
-            client_payload: payload
-        });
+    /** @type {PipelineRunArgs} */
+    const args = {
+        resources: {
+            repositories,
+        },
+        templateParameters: parameters,
     }
-    catch (err) {
-        await cli.issues.createComment({
-            body: `Heya @${requestingUser}, I couldn't dispatch the ${event} event`,
-            issue_number: request.issueNumber,
-            owner: "microsoft",
-            repo: "TypeScript"
-        });
-        return;
-    }
-}
 
-/**
- * @param {number} duration - in seconds
- */
-async function sleep(duration) {
-    return new Promise(r => {
-        setTimeout(r, duration * 1000);
-    });
-}
 
-/**
- * @param {RequestInfo} request
- * @param {string} event
- * @param {Record<string, unknown>} payload
- * @param {string} message
- */
-async function triggerGHActionWithComment(request, event, payload, message) {
-    const cli = getGHClient();
-    await triggerGHAction(request, event, payload);
-    await sleep(2);
-    // we sleep because it takes a bit for the triggered event to cause a new run to appear
-    // this improves our odds of findings the new run, rather than the old one
-    // TODO: If GH ever makes the `repository_dispatch` event actually return the scheduled jobs,
-    // use that info here
-    const workflow = await cli.actions.listWorkflowRunsForRepo({
-        owner: "microsoft",
-        repo: "TypeScript",
-        branch: "main",
-        event: "repository_dispatch"
-    });
-    const requestingUser = request.requestingUser;
-    await cli.issues.createComment({
-        body: `Heya @${requestingUser}, I've started to ${message} for you. [Here's the link to my best guess at the log](${workflow.data.workflow_runs[0].html_url}).`,
-        issue_number: request.issueNumber,
-        owner: "microsoft",
-        repo: "TypeScript"
-    });
-}
+    info.log(`Trigger pipeline ${definitionId} on ${info.issueNumber}`)
+    const build = await getVSTSTypeScriptClient().getBuildApi();
+    // The new pipelines API is not yet supported by the node client, so we have to do this manually.
+    // The request was reverse engineered from the HTTP requests made by the azure devops UI, the node client, and the Go client (which has implemented this).
+    // https://github.com/microsoft/azure-devops-go-api/blob/8dbf8bfd3346f337d914961fab01df812985dcb8/azuredevops/v7/pipelines/client.go#L446
+    const verData = await build.vsoClient.getVersioningData("7.1-preview.1", "pipelines", "7859261e-d2e9-4a68-b820-a5d84cc5bb3d", { project: typeScriptProjectId, pipelineId: definitionId });
+    const url = verData.requestUrl;
+    const options = build.createRequestOptions('application/json', verData.apiVersion);
+    assert(url);
 
-/**
- * @typedef {Object} CommentAction
- * @property {(req: RequestInfo, log: (s: string) => void, match: RegExpExecArray) => Promise<void>} task
- * @property {("MEMBER" | "OWNER" | "COLLABORATOR")[]} relationships
- * @property {boolean} prOnly
- */
-
-/**
- * @param {(req: RequestInfo, log: (s: string) => void, match: RegExpExecArray) => Promise<void>} task
- * @param {("MEMBER" | "OWNER" | "COLLABORATOR")[]=} relationships
- * @param {boolean=} prOnly
- * @returns {CommentAction}
- */
-function action(task, relationships = ["MEMBER", "OWNER", "COLLABORATOR"], prOnly = true) {
+    const response = await build.rest.create(url, args, options);
     return {
-        task,
-        relationships,
-        prOnly
+        kind: "resolved",
+        distinctId: info.distinctId,
+        url: response.result._links.web.href,
     };
 }
 
-const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
-    .set(/run dt slower/, action(async (request, log) => await makeNewBuildWithComments(request, "Definitely Typed test suite", 18, log)))
-    .set(/pack this/, action(async (request, log) => await makeNewBuildWithComments(request, "tarball bundle task", 19, log)))
-    .set(/(?:new )?perf test(?: this)?(?: (\S+)?)?/, action(async (request, log, match) => {
-        let preset = match[1] || "regular";
+/**
+ * @param {string} workflowId
+ * @param {{ distinct_id: string; issue_number: string; status_comment_id: string }} info
+ * @param {Record<string, string>} inputs
+ */
 
-        await makeNewPipelineRunWithComments(request, `${preset} perf test suite`, 69, log, p => {
-            // makeNewPipelineRunWithComments assumes that the pipeline is defined on TypeScript,
-            // but this pipeline is defined on typescript-benchmarking, so we move the self reference
-            // over to TypeScript (the name known to the benchmark pipeline).
-            const self = p.resources?.repositories?.self;
-            assert(self);
-            return {
-                ...p,
-                resources: {
-                    repositories: {
-                        TypeScript: self,
-                    }
-                },
-                templateParameters: {
-                    ...p.templateParameters,
-                    tsperf_preset: preset,
-                }
-            }
-        });
-    }))
-    .set(/run dt(?! slower)/, action(async (request, log) => await makeNewBuildWithComments(request, "parallelized Definitely Typed test suite", 23, log, async p => ({
-        ...p,
-        parameters: JSON.stringify({
-            ...JSON.parse(p.parameters),
-            DT_SHA: (await getGHClient().repos.getBranch({owner: "DefinitelyTyped", repo: "DefinitelyTyped", branch: "master"})).data.commit.sha
+/**
+ * This queues a build using the AzDO Pipelines API.
+ * 
+ * @typedef {{
+*    workflowId: string;
+*    info: RequestInfo;
+*    inputs: Record<string, string>;
+* }} CreateWorkflowDispatchRequest
+* 
+* @param {CreateWorkflowDispatchRequest} arg
+* @returns {Promise<UnresolvedGitHubRun>}
+*/
+async function createWorkflowDispatch({ workflowId, info, inputs }) {
+    const parameters = createParameters(info, inputs);
+
+    const cli = getGHClient();
+    await cli.actions.createWorkflowDispatch({
+        owner: "microsoft",
+        repo: "TypeScript",
+        ref: "main",
+        workflow_id: workflowId,
+        inputs: parameters,
+    });
+
+    return {
+        kind: "unresolvedGitHub",
+        distinctId: info.distinctId
+    }
+}
+
+
+const commands = (/** @type {Map<RegExp, Command>} */ (new Map()))
+    .set(/run dt slower/, createCommand((request) => {
+        return queueBuild({
+            definitionId: 18,
+            sourceBranch: `refs/pull/${request.issueNumber}/merge`,
+            info: request,
+            inputs: {}
         })
-    }))))
-    .set(/user test this slower/, action(async (request, log) => await makeNewBuildWithComments(request, "community code test suite", 24, log, async p => {
-        const cli = getGHClient();
-        const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
-
-        return {...p, parameters: JSON.stringify({
-            ...JSON.parse(p.parameters),
-            target_fork: pr.head.repo?.owner.login,
-            target_branch: pr.head.ref
-        })};
-    })))
-    .set(/user test this(?: inline)?(?! slower)/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite", 47, log, async p => {
-        const cli = getGHClient();
-        const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
-
-        return {
-            ...p,
+    }))
+    .set(/pack this/, createCommand((request) => {
+        return queueBuild({
+            definitionId: 19,
+            sourceBranch: `refs/pull/${request.issueNumber}/merge`,
+            info: request,
+            inputs: {}
+        })
+    }))
+    .set(/(?:new )?perf test(?: this)?(?: (\S+)?)?/, createCommand((request) => {
+        return createPipelineRun({
+            definitionId: 69,
+            repositories: {
+                TypeScript: {
+                    refName: `refs/pull/${request.issueNumber}/merge`,
+                }
+            },
+            info: request,
+            inputs: {
+                tsperf_preset: request.match[1] || "regular",
+            }
+        })
+    }))
+    .set(/run dt(?! slower)/, createCommand(async (request) => {
+        return queueBuild({
+            definitionId: 23,
+            sourceBranch: `refs/pull/${request.issueNumber}/merge`,
+            info: request,
+            inputs: {
+                DT_SHA: (await getGHClient().repos.getBranch({owner: "DefinitelyTyped", repo: "DefinitelyTyped", branch: "master"})).data.commit.sha
+            }
+        })
+    }))
+    .set(/user test this(?: inline)?(?! slower)/, createCommand(async (request) => {
+        const pr = (await getGHClient().pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
+        return queueBuild({
+            definitionId: 47,
             sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
-                post_result: true,
+            info: request,
+            inputs: {
+                post_result: "true",
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref
-            })
-        };
-    })))
-    .set(/user test tsserver/, action(async (request, log) => await makeNewBuildWithComments(request, "diff-based user code test suite (tsserver)", 47, log, async p => {
-        const cli = getGHClient();
-        const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
-
-        return {
-            ...p,
+            }
+        })
+    }))
+    .set(/user test tsserver/, createCommand(async (request) => {
+        const pr = (await getGHClient().pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
+        return queueBuild({
+            definitionId: 47,
             sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
-                post_result: true,
+            info: request,
+            inputs: {
+                post_result: "true",
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
                 entrypoint: "tsserver",
-                prng_seed: pr.id,
-            })
-        };
-    })))
-    .set(/test top(\d{1,3})/, action(async (request, log, match) => await makeNewBuildWithComments(request, "diff-based top-repos suite", 47, log, async p => {
-        const cli = getGHClient();
-        const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
-        const numRepos = +match[1];
-
-        return {
-            ...p,
+                prng_seed: `${pr.id}`,
+            }
+        })
+    }))
+    .set(/test top(\d{1,3})/, createCommand(async (request) => {
+        const pr = (await getGHClient().pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
+        return queueBuild({
+            definitionId: 47,
             sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
-                post_result: true,
+            info: request,
+            inputs: {
+                post_result: "true",
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
-                top_repos: true,
-                repo_count: numRepos,
-            })
-        };
-    })))
-    .set(/test tsserver top(\d{1,3})/, action(async (request, log, match) => await makeNewBuildWithComments(request, "diff-based top-repos suite (tsserver)", 47, log, async p => {
-        const cli = getGHClient();
-        const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
-        const numRepos = +match[1];
-
-        return {
-            ...p,
+                top_repos: "true",
+                repo_count: request.match[1]
+            }
+        })
+    }))
+    .set(/test tsserver top(\d{1,3})/, createCommand(async (request) => {
+        const pr = (await getGHClient().pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
+        return queueBuild({
+            definitionId: 47,
             sourceBranch: "",
-            parameters: JSON.stringify({
-                ...JSON.parse(p.parameters),
-                post_result: true,
+            info: request,
+            inputs: {
+                post_result: "true",
                 old_ts_repo_url: pr.base.repo.clone_url,
                 old_head_ref: pr.base.ref,
-                top_repos: true,
-                repo_count: numRepos,
+                top_repos: "true",
+                repo_count: request.match[1],
                 entrypoint: "tsserver",
-                prng_seed: pr.id,
-            })
-        };
-    })))
-    .set(/cherry-?pick (?:this )?(?:in)?to (\S+)?/, action(async (request, log, match) => {
-        const targetBranch = match[1];
-        const requestingUser = request.requestingUser;
+                prng_seed: `${pr.id}`,
+            }
+        })
+    }))
+    .set(/cherry-?pick (?:this )?(?:in)?to (\S+)?/, createCommand(async (request) => {
+        const targetBranch = request.match[1];
 
         const cli = getGHClient();
-        const pr = (await cli.pulls.get({ pull_number: request.issueNumber, owner: "microsoft", repo: "TypeScript" })).data;
         try {
             await cli.git.getRef({
                 owner: "Microsoft",
@@ -403,28 +356,27 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
             });
         }
         catch (_) {
-            const requestingUser = request.requestingUser;
-            await cli.issues.createComment({
-                body: `Heya @${requestingUser}, I couldn't find the branch '${targetBranch}' on Microsoft/TypeScript. You may need to make it and try again.`,
-                issue_number: pr.number,
-                owner: "Microsoft",
-                repo: "TypeScript"
-            });
-            return;
+            return {
+                kind: "error",
+                distinctId: request.distinctId,
+                error: `Branch \`${targetBranch}\` does not exist.`
+            }
         }
 
-        await triggerGHActionWithComment(request, "create-cherry-pick-pr", {
-            pr: request.issueNumber,
-            target_branch: targetBranch,
-            requesting_user: requestingUser,
-        }, `cherry-pick this into \`${targetBranch}\``);
+        return createWorkflowDispatch({
+            workflowId: "create-cherry-pick-pr.yml",
+            info: request,
+            inputs: {
+                pr: `${request.issueNumber}`,
+                target_branch: targetBranch,
+            }
+        })
     }))
-    .set(/create release-([\d\.]+)/, action(async (request, log, match) => {
-        const cli = getGHClient();
-        const targetBranch = `release-${match[1]}`;
+    .set(/create release-([\d\.]+)/, createCommand(async (request) => {
+        const targetBranch = `release-${request.match[1]}`;
         let targetBranchExists = false;
         try {
-            await cli.git.getRef({
+            await getGHClient().git.getRef({
                 owner: "Microsoft",
                 repo: "TypeScript",
                 ref: `heads/${targetBranch}`
@@ -435,27 +387,26 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
             // OK, we expect an error
         }
         if (targetBranchExists) {
-            // If there's no error, call it off, the branch already exists
-            const requestingUser = request.requestingUser;
-            await cli.issues.createComment({
-                body: `Heya @${requestingUser}, the branch '${targetBranch}' already seems to exist on microsoft/TypeScript. You should prepare it for the release by hand.`,
-                issue_number: request.issueNumber,
-                owner: "Microsoft",
-                repo: "TypeScript"
-            });
-            return;
+            return {
+                kind: "error",
+                distinctId: request.distinctId,
+                error: `Branch \`${targetBranch}\` already exists.`
+            }
         }
-        await triggerGHActionWithComment(request, "new-release-branch", {
-            package_version: `${match[1]}.0-beta`,
-            core_major_minor: match[1],
-            core_tag: "beta",
-            branch_name: targetBranch
-        }, `create the \`${targetBranch}\` branch`);
+        return createWorkflowDispatch({
+            workflowId: "new-release-branch.yaml",
+            info: request,
+            inputs: {
+                package_version: `${request.match[1]}.0-beta`,
+                core_major_minor: request.match[1],
+                core_tag: "beta",
+                branch_name: targetBranch
+            }
+        })
     }, undefined, false))
-    .set(/bump release-([\d\.]+)/, action(async (request, log, match) => {
+    .set(/bump release-([\d\.]+)/, createCommand(async (request) => {
         const cli = getGHClient();
-        const targetBranch = `release-${match[1]}`;
-        const requestingUser = request.requestingUser;
+        const targetBranch = `release-${request.match[1]}`;
         try {
             await cli.git.getRef({
                 owner: "Microsoft",
@@ -465,13 +416,11 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
         }
         catch (_) {
             // Branch does not exist
-            await cli.issues.createComment({
-                body: `Heya @${requestingUser}, the branch '${targetBranch}' does not seem to exist on microsoft/TypeScript.`,
-                issue_number: request.issueNumber,
-                owner: "Microsoft",
-                repo: "TypeScript"
-            });
-            return;
+            return {
+                kind: "error",
+                distinctId: request.distinctId,
+                error: `Branch \`${targetBranch}\` does not exist.`
+            }
         }
         const contentResponse = await cli.repos.getContent({
             owner: "microsoft",
@@ -480,13 +429,11 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
             path: "package.json"
         });
         if (Array.isArray(contentResponse.data) || contentResponse.data.type !== "file" || !contentResponse.data.content) {
-            await cli.issues.createComment({
-                body: `Heya @${requestingUser}, the branch '${targetBranch}' does not seem to have a \`package.json\` I can look up its current version in.`,
-                issue_number: request.issueNumber,
-                owner: "Microsoft",
-                repo: "TypeScript"
-            });
-            return;
+            return {
+                kind: "error",
+                distinctId: request.distinctId,
+                error: `Branch \`${targetBranch}\` does not have a package.json`
+            }
         }
         /** @type {string} */
         let currentVersion;
@@ -495,39 +442,240 @@ const commands = (/** @type {Map<RegExp, CommentAction>} */(new Map()))
             currentVersion = packageContent.version;
         }
         catch (_) {
-            await cli.issues.createComment({
-                body: `Heya @${requestingUser}, the branch '${targetBranch}' had a \`package.json\`, but it didn't seem to be valid JSON.`,
-                issue_number: request.issueNumber,
-                owner: "Microsoft",
-                repo: "TypeScript"
-            });
-            return;
+            return {
+                kind: "error",
+                distinctId: request.distinctId,
+                error: `Branch \`${targetBranch}\` has an invalid package.json`
+            }
         }
         const parts = currentVersion.split(".");
         const majorMinor = parts.slice(0, 2).join(".");
         // > X.X.0-beta -> X.X.1-rc -> X.X.2 -> X.X.3
         const new_version = `${majorMinor}.${currentVersion.indexOf("beta") >= 0 ? "1-rc" : currentVersion.indexOf("rc") >= 0 ? "2" : (Number(parts[2]) + 1)}`;
-        await triggerGHActionWithComment(request, "set-version", {
-            package_version: new_version,
-            core_major_minor: majorMinor,
-            branch_name: targetBranch
-        }, `update the version number on \`${targetBranch}\` to \`${new_version}\``);
-    }, undefined, false))
-    .set(/sync release-([\d\.]+)/, action(async (request, log, match) => {
-        const branch = `release-${match[1]}`;
-        await triggerGHActionWithComment(request, "sync-branch", {
-            branch_name: branch
-        }, `sync \`${branch}\` with main`);
-    }, undefined, false))
-    .set(/run repros/, action(async (request, log, match) => {
-        await triggerGHActionWithComment(request, "run-twoslash-repros", { number: request.issueNumber }, `run the code sample repros`);
-    }, undefined, false));
 
+        return createWorkflowDispatch({
+            workflowId: "set-version.yaml",
+            info: request,
+            inputs: {
+                package_version: new_version,
+                core_major_minor: majorMinor,
+                branch_name: targetBranch
+            }
+        })
+    }, undefined, false))
+    .set(/sync release-([\d\.]+)/, createCommand(async (request) => {
+        const branch = `release-${request.match[1]}`;
+        return createWorkflowDispatch({
+            workflowId: "sync-branch.yaml",
+            info: request,
+            inputs: {
+                branch_name: branch
+            }
+        })
+    }, undefined, false))
+    .set(/run repros/, createCommand(async (request) => {
+        return createWorkflowDispatch({
+            workflowId: "run-twoslash-repros.yaml",
+            info: request,
+            inputs: {
+                number: `${request.issueNumber}`
+            }
+        })
+    }, undefined, false))
 
 const botCall = "@typescript-bot";
 for (const [key, value] of [...commands.entries()]) {
     commands.delete(key);
     commands.set(new RegExp(`${botCall} ${key.source}`, "i"), value);
+}
+
+/**
+ * @param {string} distinctId
+ */
+function getStatusPlaceholder(distinctId) {
+    return `<!--status-${distinctId}-start-->🔄<!--status-${distinctId}-end-->`;
+}
+
+/**
+ * @param {string} distinctId
+ */
+function getResultPlaceholder(distinctId) {
+    // This string is known to other workflows/pipelines. Do not change without updating everything.
+    return `<!--result-${distinctId}-->`;
+}
+
+/**
+ * @typedef {{
+ *     log: (s: string) => void;
+ *     issueNumber: number;
+ *     commentId: number;
+ *     commentBody: string;
+ *     isPr: boolean;
+ *     commentUser: string;
+ *     authorAssociation: AuthorAssociation
+ * }} WebhookParams 
+ * @param {WebhookParams} params */
+async function webhook(params) {
+    const log = params.log;
+    const cli = getGHClient();
+
+    const lines = params.commentBody.split("\n").map((line) => line.trim());
+
+    const applicableCommands = Array.from(commands.entries()).filter(([, command]) => {
+        if (!params.isPr && command.prOnly) {
+            return false;
+        }
+        return command.authorAssociations.includes(params.authorAssociation);
+    });
+
+    if (applicableCommands.length === 0) {
+        return;
+    }
+
+    let commandsToRun = [];
+
+    for (let line of lines) {
+        if (!line.startsWith(botCall)) {
+            continue;
+        }
+        line = line.slice(botCall.length).trim();
+
+        for (const [key, command] of applicableCommands) {
+            const match = key.exec(line);
+            if (!match) {
+                continue;
+            }
+            commandsToRun.push({ name: line, match, fn: command.fn });
+        }
+    }
+
+    if (commandsToRun.length === 0) {
+        return;
+    }
+
+    const start = Date.now();
+    const created = `>=${new Date(start).toISOString()}`;
+
+    const commandInfos = commandsToRun.map((obj, index) => ({ ...obj, distinctId: `${params.commentId}-${index}` }));
+
+    const statusCommentBody = `
+Starting jobs; this comment will be updated as builds start and complete.
+
+| Command | Status | Results |
+| ------- | ------ | ------- |
+${
+        commandInfos.map(({ name, distinctId }) =>
+            `| \`${name}\` | ${getStatusPlaceholder(distinctId)} | ${getResultPlaceholder(distinctId)} |`
+        )
+            .join("\n")
+    }
+`.trim();
+
+    const statusComment = await cli.issues.createComment({
+        owner: "microsoft",
+        repo: "TypeScript",
+        issue_number: params.issueNumber,
+        body: statusCommentBody,
+    });
+
+    const statusCommentId = statusComment.data.id;
+
+    /** @type {Run[]} */
+    const startedRuns = await Promise.all(commandInfos.map(async ({ match, fn, distinctId }) => {
+        try {
+            return await fn({
+                match,
+                distinctId,
+                issueNumber: params.issueNumber,
+                statusCommentId: statusCommentId,
+                requestingUser: params.commentUser,
+                isPr: params.isPr,
+                log: log,
+            });
+        } catch (e) {
+            // TODO: short error message
+            return { kind: "error", distinctId, error: `${e}` };
+        }
+    }));
+
+    async function updateComment() {
+        const comment = await cli.issues.getComment({
+            owner: "microsoft",
+            repo: "TypeScript",
+            comment_id: statusCommentId,
+        });
+
+        const originalBody = comment.data.body;
+        let body = comment.data.body;
+        assert(body);
+
+        for (const run of startedRuns) {
+            const toReplace = getStatusPlaceholder(run.distinctId);
+            let replacement;
+
+            switch (run.kind) {
+                case "unresolvedGitHub":
+                    // Do nothing
+                    break;
+                case "resolved":
+                    replacement = `[✅ Started](${run.url})`;
+                    break;
+                case "error":
+                    replacement = `❌ Error: ${run.error}`;
+                    break;
+            }
+
+            if (replacement) {
+                body = body.replace(toReplace, replacement);
+            }
+        }
+
+        if (body === originalBody) {
+            return;
+        }
+
+        await cli.issues.updateComment({
+            owner: "microsoft",
+            repo: "TypeScript",
+            comment_id: statusCommentId,
+            body,
+        });
+    }
+
+    await updateComment();
+    log("Updated comment with build links");
+
+    // Emperically, this process only takes 2-3 seconds to complete,
+    // but stick a limit on it just in case.
+    for (let i = 0; i < 50; i++) {
+        if (!startedRuns.some((run) => run.kind === "unresolvedGitHub")) {
+            break;
+        }
+
+        await sleep(500);
+
+        const response = await cli.actions.listWorkflowRunsForRepo({
+            owner: "microsoft",
+            repo: "TypeScript",
+            created,
+            exclude_pull_requests: true,
+        });
+        const runs = response.data.workflow_runs;
+
+        for (const [i, run] of startedRuns.entries()) {
+            if (run.kind === "unresolvedGitHub") {
+                const match = runs.find((candidate) => candidate.name?.includes(run.distinctId));
+                if (match) {
+                    startedRuns[i] = { kind: "resolved", distinctId: run.distinctId, url: match.html_url };
+                }
+            }
+        }
+    }
+
+    log("Found runs");
+
+    await updateComment();
+    log("Updated comment with build links");
 }
 
 /** @type {import("@azure/functions").HttpHandler} */
@@ -562,70 +710,17 @@ async function handler(request, context) {
 
     const issueNumber = "issue" in event ? event.issue.number : event.pull_request.number;
 
-    const command = matchesCommand(context, comment.body, isPr, comment.author_association);
-    if (!command) {
-        return {};
-    }
-
-    context.log('GitHub Webhook triggered!', comment.body);
-    await command({
+    await webhook({
+        log: context.log,
         issueNumber,
+        commentId: comment.id,
+        commentBody: comment.body,
         isPr,
-        requestingUser: comment.user.login,
-        statusCommentId: comment.id
+        commentUser: comment.user.login,
+        authorAssociation: comment.author_association,
     });
 
     return {};
-}
-
-/**
- * @param {import("@azure/functions").InvocationContext} context
- * @param {string} body
- * @param {boolean} isPr
- * @param {string} authorAssociation
- * @returns {undefined | ((req: RequestInfo) => Promise<void>)}
- */
-function matchesCommand(context, body, isPr, authorAssociation) {
-    if (!body) {
-        return undefined;
-    }
-
-    if (!body.includes(botCall)) {
-        return undefined;
-    }
-
-    const applicableActions = Array.from(commands.entries()).filter(e => {
-        if (!isPr && e[1].prOnly) {
-            return false;
-        }
-        return e[1].relationships.some(r => r === authorAssociation);
-    });
-    if (!applicableActions.length) {
-        return undefined;
-    }
-
-    /** @type {((req: RequestInfo) => Promise<void>)[]} */
-    let results = [];
-
-    const lines = new Set(body.split("\n").map(s => s.trim()).filter(s => s));
-    for (const line of lines) {
-        for (const [key, action] of applicableActions) {
-            if (key.test(line)) {
-                const match = key.exec(line);
-                assert(match);
-                results.push(r => action.task(r, s => context.log(s), match));
-                break;
-            }
-        }
-    }
-
-    if (!results.length) {
-        return undefined;
-    }
-    if (results.length === 1) {
-        return results[0];
-    }
-    return async (req) => { await Promise.all(results.map(r => r(req))) };
 }
 
 app.http('GithubCommentReader', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "SEE LICENSE IN ASSOCIATED REPO",
       "dependencies": {
         "@azure/functions": "^4.2.0",
-        "@octokit/rest": "^20.0.2",
         "@octokit/webhooks-methods": "^4.0.0",
-        "azure-devops-node-api": "^12.4.0"
+        "azure-devops-node-api": "^12.4.0",
+        "octokit": "^3.1.2"
       },
       "devDependencies": {
         "@octokit/webhooks-types": "^7.3.1",
@@ -43,10 +43,105 @@
         "node": ">=14"
       }
     },
+    "node_modules/@octokit/app": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
+      "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
+      "dependencies": {
+        "@octokit/auth-app": "^6.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/types": "^12.0.0",
+        "@octokit/webhooks": "^12.0.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.0.3.tgz",
+      "integrity": "sha512-9N7IlBAKEJR3tJgPSubCxIDYGXSdc+2xbkjYpk9nCyqREnH8qEMoMhiEB1WgoA9yTFp91El92XNXAi+AjuKnfw==",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "^10.0.0",
+        "universal-github-app-jwt": "^1.1.2",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.0.1.tgz",
+      "integrity": "sha512-RE0KK0DCjCHXHlQBoubwlLijXEKfhMhKm9gO56xYvFmP1QTMb+vvwRPmQLLx0V+5AvV9N9I3lr1WyTzwL3rMDg==",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/types": "^12.0.0",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.0.1.tgz",
+      "integrity": "sha512-yxU0rkL65QkjbqQedgVx3gmW7YM5fF+r5uaSj9tM/cQGVqloXcqP2xK90eTyYvl29arFVCW8Vz4H/t47mL0ELw==",
+      "dependencies": {
+        "@octokit/oauth-methods": "^4.0.0",
+        "@octokit/request": "^8.0.0",
+        "@octokit/types": "^12.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.0.1.tgz",
+      "integrity": "sha512-N94wWW09d0hleCnrO5wt5MxekatqEJ4zf+1vSe8MKMrhZ7gAXKFOKrDEZW2INltvBWJCyDUELgGRv8gfErH1Iw==",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.0.0",
+        "@octokit/oauth-methods": "^4.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/types": "^12.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@octokit/auth-token": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+      "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      },
       "engines": {
         "node": ">= 18"
       }
@@ -93,10 +188,62 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@octokit/oauth-app": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+      "integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/oauth-methods": "^4.0.0",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+      "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.0.1.tgz",
+      "integrity": "sha512-1NdTGCoBHyD6J0n2WGXg9+yDLZrRNZ0moTEex/LSPr49m530WNKcCfXDghofYptr3st3eTii+EHoG5k/o+vbtw==",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "btoa-lite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@octokit/openapi-types": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.1.0.tgz",
       "integrity": "sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw=="
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.0.tgz",
+      "integrity": "sha512-7HcYW5tP7/Z6AETAPU14gp5H5KmCPT3hmJrS/5tO7HIgbwenYmgw4OY9Ma54FDySuxMwD+wsJlxtuGWwuZuItA==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.1.5",
@@ -105,17 +252,6 @@
       "dependencies": {
         "@octokit/types": "^12.4.0"
       },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=5"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
-      "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
       "engines": {
         "node": ">= 18"
       },
@@ -137,10 +273,41 @@
         "@octokit/core": ">=5"
       }
     },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+      "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.1.3.tgz",
+      "integrity": "sha512-pfyqaqpc0EXh5Cn4HX9lWYsZ4gGbjnSmUILeu4u2gnuM50K/wIk9s1Pxt3lVeVwekmITgN/nJdoh43Ka+vye8A==",
+      "dependencies": {
+        "@octokit/types": "^12.2.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5.0.0"
+      }
+    },
     "node_modules/@octokit/request": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.6.tgz",
-      "integrity": "sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
+      "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
       "dependencies": {
         "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
@@ -164,26 +331,26 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@octokit/rest": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
-      "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
-      "dependencies": {
-        "@octokit/core": "^5.0.0",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-request-log": "^4.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@octokit/types": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.4.0.tgz",
       "integrity": "sha512-FLWs/AvZllw/AGVs+nJ+ELCDZZJk+kY0zMen118xhL2zD0s1etIUHm1odgjP7epxYU1ln7SZxEUWYop5bhsdgQ==",
       "dependencies": {
         "@octokit/openapi-types": "^19.1.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.1.0.tgz",
+      "integrity": "sha512-ppqZ1DyHhZklpeuxnx7WRn5S5WRxjHYt/fQlr33JNvbK+Dpaz6XFD5Zw/AFri62J4NH3jKreHeQFQkLouMqdog==",
+      "dependencies": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/webhooks-methods": "^4.0.0",
+        "@octokit/webhooks-types": "7.3.2",
+        "aggregate-error": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/webhooks-methods": {
@@ -195,18 +362,46 @@
       }
     },
     "node_modules/@octokit/webhooks-types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.3.1.tgz",
-      "integrity": "sha512-u6355ZsZnHwmxen30SrqnYb1pXieBFkYgkNzt+Ed4Ao5tupN1OErHfzwiV6hq6duGkDAYASbq7/uVJQ69PjLEg==",
-      "dev": true
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.3.2.tgz",
+      "integrity": "sha512-JWOoOgtWTFnTSAamPXXyjTY5/apttvNxF+vPBnwdSu5cj5snrd7FO0fyw4+wTXy8fHduq626JjhO+TwCyyA6vA=="
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.133",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.133.tgz",
+      "integrity": "sha512-sr852MAL/79rjDelXP6ZuJ6GwOvXIRrFAoC8a+w91mZ5XR71CuzSgo1d0+pG1qgfPhjFgaibu7SWaoC5BA7pyQ=="
+    },
+    "node_modules/@types/btoa-lite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+      "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz",
+      "integrity": "sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "18.19.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
       "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/azure-devops-node-api": {
@@ -223,6 +418,21 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
+    "node_modules/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/call-bind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -234,6 +444,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/define-data-property": {
@@ -253,6 +471,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -331,10 +557,106 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/object-inspect": {
       "version": "1.13.1",
@@ -342,6 +664,26 @@
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/octokit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+      "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+      "dependencies": {
+        "@octokit/app": "^14.0.2",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-graphql": "^4.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/plugin-retry": "^6.0.0",
+        "@octokit/plugin-throttling": "^8.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/once": {
@@ -364,6 +706,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {
@@ -444,8 +830,16 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.2.tgz",
+      "integrity": "sha512-t1iB2FmLFE+yyJY9+3wMx0ejB+MQpEVkH0gQv7dR6FZyltyq+ZZO0uDpbopxhrZ3SLEO4dCEkIujOMldEQ2iOA==",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.0",
+        "jsonwebtoken": "^9.0.2"
+      }
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -456,6 +850,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -473,10 +872,87 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
       "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
     },
+    "@octokit/app": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
+      "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
+      "requires": {
+        "@octokit/auth-app": "^6.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/types": "^12.0.0",
+        "@octokit/webhooks": "^12.0.4"
+      }
+    },
+    "@octokit/auth-app": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.0.3.tgz",
+      "integrity": "sha512-9N7IlBAKEJR3tJgPSubCxIDYGXSdc+2xbkjYpk9nCyqREnH8qEMoMhiEB1WgoA9yTFp91El92XNXAi+AjuKnfw==",
+      "requires": {
+        "@octokit/auth-oauth-app": "^7.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "^10.0.0",
+        "universal-github-app-jwt": "^1.1.2",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-app": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.0.1.tgz",
+      "integrity": "sha512-RE0KK0DCjCHXHlQBoubwlLijXEKfhMhKm9gO56xYvFmP1QTMb+vvwRPmQLLx0V+5AvV9N9I3lr1WyTzwL3rMDg==",
+      "requires": {
+        "@octokit/auth-oauth-device": "^6.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/types": "^12.0.0",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-device": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.0.1.tgz",
+      "integrity": "sha512-yxU0rkL65QkjbqQedgVx3gmW7YM5fF+r5uaSj9tM/cQGVqloXcqP2xK90eTyYvl29arFVCW8Vz4H/t47mL0ELw==",
+      "requires": {
+        "@octokit/oauth-methods": "^4.0.0",
+        "@octokit/request": "^8.0.0",
+        "@octokit/types": "^12.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/auth-oauth-user": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.0.1.tgz",
+      "integrity": "sha512-N94wWW09d0hleCnrO5wt5MxekatqEJ4zf+1vSe8MKMrhZ7gAXKFOKrDEZW2INltvBWJCyDUELgGRv8gfErH1Iw==",
+      "requires": {
+        "@octokit/auth-oauth-device": "^6.0.0",
+        "@octokit/oauth-methods": "^4.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/types": "^12.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
     "@octokit/auth-token": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
+    },
+    "@octokit/auth-unauthenticated": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+      "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+      "requires": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      }
     },
     "@octokit/core": {
       "version": "5.1.0",
@@ -511,10 +987,48 @@
         "universal-user-agent": "^6.0.0"
       }
     },
+    "@octokit/oauth-app": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+      "integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+      "requires": {
+        "@octokit/auth-oauth-app": "^7.0.0",
+        "@octokit/auth-oauth-user": "^4.0.0",
+        "@octokit/auth-unauthenticated": "^5.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/oauth-methods": "^4.0.0",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/oauth-authorization-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+      "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA=="
+    },
+    "@octokit/oauth-methods": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.0.1.tgz",
+      "integrity": "sha512-1NdTGCoBHyD6J0n2WGXg9+yDLZrRNZ0moTEex/LSPr49m530WNKcCfXDghofYptr3st3eTii+EHoG5k/o+vbtw==",
+      "requires": {
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "btoa-lite": "^1.0.0"
+      }
+    },
     "@octokit/openapi-types": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.1.0.tgz",
       "integrity": "sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw=="
+    },
+    "@octokit/plugin-paginate-graphql": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.0.tgz",
+      "integrity": "sha512-7HcYW5tP7/Z6AETAPU14gp5H5KmCPT3hmJrS/5tO7HIgbwenYmgw4OY9Ma54FDySuxMwD+wsJlxtuGWwuZuItA==",
+      "requires": {}
     },
     "@octokit/plugin-paginate-rest": {
       "version": "9.1.5",
@@ -524,12 +1038,6 @@
         "@octokit/types": "^12.4.0"
       }
     },
-    "@octokit/plugin-request-log": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
-      "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
-      "requires": {}
-    },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.2.0.tgz",
@@ -538,10 +1046,29 @@
         "@octokit/types": "^12.3.0"
       }
     },
+    "@octokit/plugin-retry": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+      "integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
+      "requires": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.1.3.tgz",
+      "integrity": "sha512-pfyqaqpc0EXh5Cn4HX9lWYsZ4gGbjnSmUILeu4u2gnuM50K/wIk9s1Pxt3lVeVwekmITgN/nJdoh43Ka+vye8A==",
+      "requires": {
+        "@octokit/types": "^12.2.0",
+        "bottleneck": "^2.15.3"
+      }
+    },
     "@octokit/request": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.6.tgz",
-      "integrity": "sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
+      "integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
       "requires": {
         "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
@@ -559,17 +1086,6 @@
         "once": "^1.4.0"
       }
     },
-    "@octokit/rest": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
-      "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
-      "requires": {
-        "@octokit/core": "^5.0.0",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-request-log": "^4.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
-      }
-    },
     "@octokit/types": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.4.0.tgz",
@@ -578,24 +1094,60 @@
         "@octokit/openapi-types": "^19.1.0"
       }
     },
+    "@octokit/webhooks": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.1.0.tgz",
+      "integrity": "sha512-ppqZ1DyHhZklpeuxnx7WRn5S5WRxjHYt/fQlr33JNvbK+Dpaz6XFD5Zw/AFri62J4NH3jKreHeQFQkLouMqdog==",
+      "requires": {
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/webhooks-methods": "^4.0.0",
+        "@octokit/webhooks-types": "7.3.2",
+        "aggregate-error": "^3.1.0"
+      }
+    },
     "@octokit/webhooks-methods": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.0.0.tgz",
       "integrity": "sha512-M8mwmTXp+VeolOS/kfRvsDdW+IO0qJ8kYodM/sAysk093q6ApgmBXwK1ZlUvAwXVrp/YVHp6aArj4auAxUAOFw=="
     },
     "@octokit/webhooks-types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.3.1.tgz",
-      "integrity": "sha512-u6355ZsZnHwmxen30SrqnYb1pXieBFkYgkNzt+Ed4Ao5tupN1OErHfzwiV6hq6duGkDAYASbq7/uVJQ69PjLEg==",
-      "dev": true
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.3.2.tgz",
+      "integrity": "sha512-JWOoOgtWTFnTSAamPXXyjTY5/apttvNxF+vPBnwdSu5cj5snrd7FO0fyw4+wTXy8fHduq626JjhO+TwCyyA6vA=="
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.133",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.133.tgz",
+      "integrity": "sha512-sr852MAL/79rjDelXP6ZuJ6GwOvXIRrFAoC8a+w91mZ5XR71CuzSgo1d0+pG1qgfPhjFgaibu7SWaoC5BA7pyQ=="
+    },
+    "@types/btoa-lite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+      "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="
+    },
+    "@types/jsonwebtoken": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz",
+      "integrity": "sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "18.19.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
       "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
-      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "azure-devops-node-api": {
@@ -612,6 +1164,21 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "call-bind": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
@@ -621,6 +1188,11 @@
         "get-intrinsic": "^1.2.1",
         "set-function-length": "^1.1.1"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "define-data-property": {
       "version": "1.1.1",
@@ -636,6 +1208,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "function-bind": {
       "version": "1.1.2",
@@ -687,15 +1267,118 @@
         "function-bind": "^1.1.2"
       }
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
+    "jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
+    "lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q=="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+    },
+    "octokit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+      "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+      "requires": {
+        "@octokit/app": "^14.0.2",
+        "@octokit/core": "^5.0.0",
+        "@octokit/oauth-app": "^6.0.0",
+        "@octokit/plugin-paginate-graphql": "^4.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/plugin-retry": "^6.0.0",
+        "@octokit/plugin-throttling": "^8.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -711,6 +1394,29 @@
       "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "requires": {
         "side-channel": "^1.0.4"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "set-function-length": {
@@ -772,8 +1478,16 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "universal-github-app-jwt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.2.tgz",
+      "integrity": "sha512-t1iB2FmLFE+yyJY9+3wMx0ejB+MQpEVkH0gQv7dR6FZyltyq+ZZO0uDpbopxhrZ3SLEO4dCEkIujOMldEQ2iOA==",
+      "requires": {
+        "@types/jsonwebtoken": "^9.0.0",
+        "jsonwebtoken": "^9.0.2"
+      }
     },
     "universal-user-agent": {
       "version": "6.0.1",
@@ -784,6 +1498,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "@azure/functions": "^4.2.0",
-    "@octokit/rest": "^20.0.2",
     "@octokit/webhooks-methods": "^4.0.0",
-    "azure-devops-node-api": "^12.4.0"
+    "azure-devops-node-api": "^12.4.0",
+    "octokit": "^3.1.2"
   },
   "devDependencies": {
     "@octokit/webhooks-types": "^7.3.1",


### PR DESCRIPTION
This ports in my code from https://github.com/jakebailey/workflow-trigger-testing.

This will require a bunch of pipeline/workflow updates, so this can't be merged right away.


Workflows that need to be updated:

- [ ] `pack this` (non-blocking, build does not update the status comment)
- [x] `perf test` https://github.com/microsoft/typescript-benchmarking/pull/34
- [ ] `run dt` https://github.com/microsoft/DefinitelyTyped-tools/pull/963 (needs manual pipeline change, or switch to yaml)
- [x] `user test this` https://github.com/microsoft/typescript-error-deltas/pull/132
- [x] `user test tsserver` https://github.com/microsoft/typescript-error-deltas/pull/132
- [x] `test top` https://github.com/microsoft/typescript-error-deltas/pull/132
- [x] `test tsserver top` https://github.com/microsoft/typescript-error-deltas/pull/132
- [x] `cherry-pick` https://github.com/microsoft/TypeScript/pull/57409
- [x] `create-release` https://github.com/microsoft/TypeScript/pull/57409
- [x] `bump release` https://github.com/microsoft/TypeScript/pull/57409
- [x] `sync release` https://github.com/microsoft/TypeScript/pull/57409
- [x] `run repros` https://github.com/microsoft/TypeScript/pull/57409